### PR TITLE
Removes kernel extensions that allow automatically defining rulp variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,27 +57,33 @@ Rulp is inspired by the ruby wrapper for the GLPK toolkit and the python LP libr
 	#
 
 
-	given[
+  # define variables
+  x = IV.new('x', [])
+  y = IV.new('y', [])
+  z = IV.new('z', [])
 
-	X_i >= 0,
-	Y_i >= 0,
-	Z_i >= 0
+  # define the function and create the operation
+  function = Rulp::Max(10 * x + 6 * y + 4 * z)
 
-	]
+  # add constraints to the function
+  function[
+    x >= 0,
+    y >= 0,
+    z >= 0,
+    x + y + z <= 100,
+    10 * x + 4 * y + 5 *z <= 600,
+    2 * x + 2* y + 6 * z <= 300
+  ]
 
-	result = Rulp::Max( 10 * X_i + 6 * Y_i + 4 * Z_i ) [
-	                X_i +     Y_i +     Z_i <= 100,
-	           10 * X_i + 4 * Y_i + 5 * Z_i <= 600,
-	           2 *  X_i + 2 * Y_i + 6 * Z_i <= 300
-	].solve
+  result = Rulp::Glpk(function)
 
 	##
 	# 'result' is the result of the objective function.
 	# You can retrieve the values of variables by using the 'value' method
 	# E.g
-	#   X_i.value == 32
-	#   Y_i.value == 67
-	#   Z_i.value == 0
+	#   x.value == 33
+	#   y.value == 66
+	#   z.value == 0
 	##
 ```
 
@@ -185,22 +191,19 @@ At this point, you should have GLPK installed. Verify it:
 #### Variables
 
 ```ruby
-	# Rulp variables are initialized as soon as they are needed so there is no
-	# need to initialize them.
-	# They follow a naming convention that defines their type.
-	# A variable is declared as a constant with one of three different suffixes.
-	# 'f' or '_f' indicates a general variable (No constraints)
-	# 'i' or '_i' indicates a integer variable
-	# 'b' or '_b' indicates a binary/boolean variable
+	# Rulp variables can be initialized with the following classes
+	# LV indicates a general variable (No constraints)
+	# IV indicates a integer variable
+	# BV indicates a binary/boolean variable
 
 
-	An_Integer_i
+	IV.new('An_Integer', [])
 	=> #<IV:0x007ffc4b651b80 @name="An_Integer">
 
-	Generalf
+	LV.new('General', [])
 	=> #<LV:0x007ffc4b651b80 @name="General">
 
-	Bool_Val_b
+	BV.new('Bool_Val', [])
 	=> #<BV:0x007ffc4b67b6b0 @name="Bool_Val">
 
 	# In some cases it is implausible to generate a unique name for every possible variable
@@ -209,13 +212,13 @@ At this point, you should have GLPK installed. Verify it:
 	# accept index parameters to create large ranges of unique variables.
 	# Examples of how indexed variables can be declared are as follows:
 
-	Item_i(4,5)
-	#<IV:0x007ffc4b3ea518 @name="Item4_5">
+	IV.new('Item', [4,5])
+	#<IV:0x007ffc4b3ea518 @name="Item4-5">
 
-	Item_i("store_3", "table_2")
-	#<IV:0x007ffc4b3a3cd0 @name="Itemstore_3_table_2">
+	IV.new("store_3", ["table_2"])
+	#<IV:0x007ffc4b3a3cd0 @name="store_3table_2">
 
-	[*0..10].map(&Unit_f)
+	[*0..10].map{|i| LV.new('Unit', [i]) }
 	=> [#<LV:0x007ffc4cc25768 @name="Unit0">,
 	 #<LV:0x007ffc4cc24cf0 @name="Unit1">,
 	 #<LV:0x007ffc4cc0fc88 @name="Unit2">,
@@ -237,16 +240,16 @@ Constraints on a variable can only use numeric literals and not other variables.
 Inter-variable constraints should be expressed as problem constrants. (Explained below.)
 
 ```ruby
-	X_i < 5
-	X_i.bounds
-	=> "X <= 5"
+	x < 5
+	x.bounds
+	=> "x <= 5"
 
-	3 <= X_i < 15
-	X_i.bounds
-	=> "3 <= X <= 15"
+	3 <= x < 15
+	x.bounds
+	=> "3 <= x <= 15"
 
-	Y_f == 10
-	Y_f.bounds
+	y == 10
+	y.bounds
 	=> "y = 10"
 ```
 
@@ -255,14 +258,14 @@ Inter-variable constraints should be expressed as problem constrants. (Explained
 Constraints are added to a problem using the :[] syntax.
 
 ```ruby
-	problem = Rulp::Max( 10 * X_i + 6 * Y_i + 4 * Z_i )
+	problem = Rulp::Max(10 * x + 6 * y + 4 * z)
 
 	problem[
-		X_i +     Y_i +     Z_i <= 100
+		x + y + z <= 100
 	]
 
 	problem[
-		10 * X_i + 4 * Y_i + 5 * Z_i <= 600
+		10 * x + 4 * y + 5 * z <= 600
 	]
 	...
 	problem.solve
@@ -271,11 +274,11 @@ Constraints are added to a problem using the :[] syntax.
 You can add multiple constraints at once by comma separating them as seen in the earlier examples:
 
 ```ruby
-	Rulp::Max( 10 * X_i + 6 * Y_i + 4 * Z_i ) [
-		                X_i +     Y_i +     Z_i <= 100,
-		           10 * X_i + 4 * Y_i + 5 * Z_i <= 600,
-		           2 *  X_i + 2 * Y_i + 6 * Z_i <= 300
-		          ]
+	Rulp::Max(10 * x + 6 * y + 4 * z) [
+    x + y + z <= 100,
+    10 * x + 4 * y + 5 * z <= 600,
+    2 * x + 2 * y + 6 * z <= 300
+  ]
 ```
 
 #### Solving or saving 'lp' files
@@ -288,11 +291,11 @@ such that the command `which [exec_name]` returns a path. (I.e they must be on y
 Given a problem there are multiple ways to initiate a solver.
 
 ```ruby
-	@problem = Rulp::Max( 10 * X_i + 6 * Y_i + 4 * Z_i ) [
-	                 X_i +     Y_i +     Z_i <= 100,
-	           	10 * X_i + 4 * Y_i + 5 * Z_i <= 600,
-	           	2 *  X_i + 2 * Y_i + 6 * Z_i <= 300
-						]
+	@problem = Rulp::Max( 10 * x + 6 * y + 4 * z ) [
+    x + y + z <= 100,
+    10 * x + 4 * y + 5 * z <= 600,
+    2 * x + 2 * y + 6 * z <= 300
+  ]
 ```
 
 Default solver:
@@ -410,13 +413,13 @@ You can then play with and attempt LP and MIP problems straight from the command
 
 ```ruby
 
-	[1] pry(main)> 13 <= X_i <= 45 # Declare integer variable
+	[1] pry(main)> 13 <= (x = IV.new('x', [])) <= 45 # Declare integer variable
 	=> X(i)[undefined]
 
-	[2] pry(main)> -15 <= Y_f <= 15 # Declare float variable
+	[2] pry(main)> -15 <= (y = LV.new('x', [])) <= 15 # Declare float variable
 	=> Y(f)[undefined]
 
-	[3] pry(main)> @problem = Rulp::Min(X_i - Y_f) # Create min problem
+	[3] pry(main)> @problem = Rulp::Min(x - y) # Create min problem
 	[info] Creating minimization problem
 	=>
 	Minimize
@@ -430,7 +433,7 @@ You can then play with and attempt LP and MIP problems straight from the command
 	 X
 	End
 
-	[4] @problem[ X_i - 2 * Y_f < 40] #Adding a problem constraint
+	[4] @problem[x - 2 * y < 40] #Adding a problem constraint
 	=>
 	Minimize
 	 obj: X -Y
@@ -450,10 +453,10 @@ You can then play with and attempt LP and MIP problems straight from the command
 	[info] Parsing result
 	=> -2.0 #(Minimal result)
 
-	[6] pry(main)> Y_f # See value calculated for Y now that solver has run
+	[6] pry(main)> y # See value calculated for Y now that solver has run
 	=> Y(f)[15.0]
 
-	[8] pry(main)> X_i
+	[8] pry(main)> x
 	=> X(i)[13.0]
 
 	# The result of the objective function (-2.0) was returned by the call to .solve
@@ -461,10 +464,10 @@ You can then play with and attempt LP and MIP problems straight from the command
 	# objective function (or any function) by calling evaluate on it.
 	# E.g
 
-	[9] (X_i - Y_f).evaluate
+	[9] (x - y).evaluate
 	=> -2.0
 
-	[10] pry(main)> (2 * X_i + 15 * Y_f).evaluate
+	[10] pry(main)> (2 * x + 15 * y).evaluate
 	=> 251.0
 ```
 
@@ -480,9 +483,10 @@ we don't. We can't partially purchase one.)
 
 ```ruby
 # Generate the data randomly for this example.
-costs, points = [*0..1000].map do |i|
-	[Purchase_b(i) * Random.rand(1.0..3.0), Purchase_b(i) * Random.rand(5.0..10.0)]
-end.transpose.map(&:sum) #We sum the array of points and array of costs to create a Rulp expression
+purchases = [*0..1000].map { |i| BV.new('Purchase', [i]) }
+costs, points = purchases.map do |p|
+	[p * Random.rand(1.0..3.0), p * Random.rand(5.0..10.0)]
+end.transpose.map{|x| x.reduce(&:+) } #We sum the array of points and array of costs to create a Rulp expression
 
 # And this is where the magic happens!. We ask rulp to maximise the number of points given
 # the constraint that costs must be less than $55
@@ -493,7 +497,7 @@ Rulp::Max(points)[
 => 538.2125623353652 (# You will get a different value as data was generated randomly)
 
 # Now how do we check which purchases were selected?
-selected_purchases = [*0..1000].map(&Purchase_b).select(&:selected?)
+selected_purchases = purchases.select(&:selected?)
 
 => [Purchase27(b)[true],
  Purchase86(b)[true],

--- a/examples/boolean_example.rb
+++ b/examples/boolean_example.rb
@@ -9,9 +9,9 @@ Rulp::log_level = Logger::INFO
 #
 ##
 
-items       = 50.times.map(&Shop_Item_b)
-items_count = items.sum
-items_costs = items.map{|item| item * Random.rand(1.0...5.0)}.sum
+items       = 50.times.map{|i| BV.new('Shop_Item', [i]) }
+items_count = items.reduce(&:+)
+items_costs = items.map{|item| item * Random.rand(1.0...5.0)}.reduce(&:+)
 
 Rulp::Min( items_costs ) [
   items_count  >= 10,

--- a/examples/simple_example.rb
+++ b/examples/simple_example.rb
@@ -16,19 +16,19 @@ Rulp::log_level = Logger::DEBUG
 #
 
 
-given[
+x = IV.new('x', [])
+y = IV.new('y', [])
+z = IV.new('z', [])
 
-X_i >= 0,
-Y_i >= 0,
-Z_i >= 0
+Rulp::Max(objective = 10 * x + 6 * y + 4 * z) [
+  x >= 0,
+  y >= 0,
+  z >= 0,
+  x + y + z <= 100,
+  10 * x + 4 * y + 5 *z <= 600,
+  2 * x + 2* y + 6 * z <= 300
+].glpk
 
-]
-
-Rulp::Max( objective = 10 * X_i + 6 * Y_i + 4 * Z_i ) [
-                            X_i +     Y_i +     Z_i <= 100,
-                       10 * X_i + 4 * Y_i + 5 * Z_i <= 600,
-                       2 *  X_i + 2 * Y_i + 6 * Z_i <= 300
-].cbc
 
 result = objective.evaluate
 

--- a/examples/whiskas_model2.rb
+++ b/examples/whiskas_model2.rb
@@ -5,7 +5,14 @@
 #
 require_relative "../lib/rulp"
 
-ingredients     = [Chicken_i, Beef_i, Mutton_i, Rice_i, Wheat_i, Gel_i]
+chicken = IV.new('Chicken', [])
+beef = IV.new('Beef', [])
+mutton = IV.new('Mutton', [])
+rice = IV.new('Rice', [])
+wheat = IV.new('Wheat', [])
+gel = IV.new('Gel', [])
+
+ingredients     = [chicken, beef, mutton, rice, wheat, gel]
 costs           = {Chicken: 0.013, Beef: 0.008, Mutton: 0.010, Rice: 0.002, Wheat: 0.005, Gel: 0.001}
 protein_percent = {Chicken: 0.100, Beef: 0.200, Mutton: 0.150, Rice: 0.000, Wheat: 0.040, Gel: 0.000}
 fat_percent     = {Chicken: 0.080, Beef: 0.100, Mutton: 0.110, Rice: 0.010, Wheat: 0.010, Gel: 0.000}
@@ -19,16 +26,16 @@ problem[
   ingredients.map{|i| protein_percent[i.name.to_sym] * i}.inject(:+) >= 8.0,
   ingredients.map{|i| fat_percent[i.name.to_sym]     * i}.inject(:+) >= 6.0,
   ingredients.map{|i| fibre_percent[i.name.to_sym]   * i}.inject(:+) <= 2.0,
-  ingredients.map{|i| salt_percent[i.name.to_sym]    * i}.inject(:+) <= 0.4,
+  ingredients.map{|i| salt_percent[i.name.to_sym]    * i}.inject(:+) <= 0.4
 ]
 
 result = problem.solve
 
 puts "Total Cost Per Can: #{result}"
 puts
-puts "Chicken: #{Chicken_i.value}"
-puts "Beef:    #{Beef_i.value}"
-puts "Mutton:  #{Mutton_i.value}"
-puts "Rice:    #{Rice_i.value}"
-puts "Wheat:   #{Wheat_i.value}"
-puts "Gel:     #{Gel_i.value}"
+puts "Chicken: #{chicken.value}"
+puts "Beef:    #{beef.value}"
+puts "Mutton:  #{mutton.value}"
+puts "Rice:    #{rice.value}"
+puts "Wheat:   #{wheat.value}"
+puts "Gel:     #{gel.value}"

--- a/lib/helpers/log.rb
+++ b/lib/helpers/log.rb
@@ -16,7 +16,7 @@ module Rulp
     end
 
     def log_level
-      @@log_level || Logger::DEBUG
+      @@log_level || Logger::WARN
     end
 
     def log(level, message)

--- a/lib/rulp/lv.rb
+++ b/lib/rulp/lv.rb
@@ -30,14 +30,7 @@ class LV
   end
 
   def self.definition(name, *args)
-    identifier = "#{name}#{args.join("_")}"
-    defined = LV::names_table["#{identifier}"]
-    case defined
-    when self then defined
-    when nil then self.new(name, args)
-    else raise StandardError.new("ERROR:\n#{name} was already defined as a variable of type #{defined.class}."+
-                              "You are trying to redefine it as a variable of type #{self}")
-    end
+    self.new(name, args)
   end
 
   def * (numeric)

--- a/lib/rulp/rulp.rb
+++ b/lib/rulp/rulp.rb
@@ -7,7 +7,7 @@ require_relative "constraint"
 require_relative "expression"
 
 require_relative "../solvers/solver"
-require_relative "../extensions/extensions"
+# require_relative "../extensions/extensions"
 require_relative "../helpers/log"
 
 require 'set'
@@ -156,6 +156,12 @@ module Rulp
 
     def output(filename=choose_file)
       IO.write(filename, self)
+    end
+
+    def _profile
+      start        = Time.now
+      return_value = yield
+      return return_value, Time.now - start
     end
 
     def solve_with(type, options={})

--- a/lib/rulp/rulp.rb
+++ b/lib/rulp/rulp.rb
@@ -23,7 +23,7 @@ module Rulp
   attr_accessor :expressions
   extend Rulp::Log
   self.print_solver_outputs = true
-  self.log_level = Logger::DEBUG
+  self.log_level = Logger::WARN
   MIN = "Minimize"
   MAX = "Maximize"
 

--- a/lib/rulp/rulp_initializers.rb
+++ b/lib/rulp/rulp_initializers.rb
@@ -5,22 +5,6 @@ module Rulp
       @args = args
       @value = nil
       @identifier = "#{self.name}#{self.args.join("_")}"
-      raise StandardError.new("Variable with the name #{self} of a different type (#{LV::names_table[self.to_s].class}) already exists") if LV::names_table[self.to_s]
-      LV::names_table[self.to_s] = self
-    end
-
-    def self.included(base)
-      base.extend(ClassMethods)
-    end
-
-    module ClassMethods
-      def names_table
-        @@names ||= {}
-      end
-
-      def clear
-        @@names = {}
-      end
     end
 
     def to_s

--- a/rulp.gemspec
+++ b/rulp.gemspec
@@ -5,7 +5,7 @@ require 'rulp/version'
 Gem::Specification.new do |s|
   s.name        = 'rulp'
   s.version     = Rulp::VERSION
-  s.date        = Date.today
+  s.date        = '2018-09-06'
   s.summary     = "Ruby Linear Programming"
   s.description = "A simple Ruby LP description DSL"
   s.authors     = ["Wouter Coppieters"]


### PR DESCRIPTION
Removes functionality for automatic variable definition like `Purchase_b`. 

Instead, this needs to be defined as `purchase = BV.new('Purchase', [])`

This allows for better compatibility when using with other ruby libraries like rails.